### PR TITLE
Fix redirect to patch edit page on creation

### DIFF
--- a/pgcommitfest/commitfest/views.py
+++ b/pgcommitfest/commitfest/views.py
@@ -432,7 +432,7 @@ def newpatch(request, cfid):
             # Now add the thread
             try:
                 doAttachThread(cf, patch, form.cleaned_data['threadmsgid'], request.user)
-                return HttpResponseRedirect("/%s/%s/edit/" % (cf.id, patch.id))
+                return HttpResponseRedirect("/patch/%s/edit/" % (patch.id,))
             except Http404:
                 # Thread not found!
                 # This is a horrible breakage of API layers


### PR DESCRIPTION
After [this refactor](https://github.com/JelteF/commitfest/commit/a173224a3c4159e03ce554b3a92e66253be5e67b) of the patch URL, when you create a patch, you're still redirected to the old patch URL, which no longer exists. 